### PR TITLE
#10 전화번호 필드 정규화

### DIFF
--- a/django/src/service/models.py
+++ b/django/src/service/models.py
@@ -5,7 +5,7 @@ class ParkingLot(models.Model):
   code        = models.PositiveIntegerField(primary_key=True)
   name        = models.CharField(max_length=128, db_index=True)
   address     = models.CharField(max_length=512, db_index=True)
-  phone_num   = models.CharField(max_length=16,  db_index=True)
+  phone_num   = models.CharField(max_length=64,  db_index=True)
   json_string = models.TextField()
   crc32       = models.PositiveIntegerField()
   version     = models.PositiveIntegerField()


### PR DESCRIPTION
* 원본의 ')' 문자를 '-' 문자로 치환하여 저장
* 원본에서 끝자리가 다른 복수의 전화번호를 '~' 문자로 표현하던 것을 비정규화 하여 리스트로 표현
* 전화번호 검색에 대하여 LIKE를 이용하여 대응할 수 있도록 수정